### PR TITLE
Mistral support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Jelle Smet
+Copyright (c) 2025 Jelle Smet
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ backends:
       model: "gpt-4o"
       max_tokens: 4096
       system: You are a helpful assistant.
+
+  mistral:
+    default:
+      token: ${{MISTRAL_OPENAI_TOKEN}}
+      max_tokens: 4096
+      model: mistral-small-latest
+      system: You are a helpful assistant.
 ```
 
 ### Backends
@@ -112,20 +119,6 @@ $ echo $?
 0
 ```
 
-### no-prose
-
-Enabling `--noprose` is useful to make sure the LLM does not add any unwanted
-explanation or formatting to the response:
-
-```
-cat test.md | clai --prompt "Convert this markdown content to asciidoc."
-= Title
-
-== Chapter 1
-
-This is chapter 1
-```
-
 ## Backends
 
 ### OpenAI
@@ -155,3 +148,18 @@ https://learn.microsoft.com/en-us/azure/ai-services/openai/
 - `max_tokens`: The maximum number of tokens the prompt is allowed to generate
 - `system`: The system prompt
 - `temperature`: The prompt temperature (default: 0)
+
+### Mistral
+
+https://mistral.ai/
+
+The following parameters are supported:
+
+- `token`: The Mistral API token
+- `max_tokens`: The maximum number of tokens the prompt is allowed to
+  generate. (CAVEAT: The token calculation is not accurate since there no
+  equivalent for tiktoken which allows to tokenize locally without external
+  dependencies)
+- `model`: The model to use
+- `system`: The system prompt
+- `temperature`: The prompt temperature (default 0)

--- a/clai/__init__.py
+++ b/clai/__init__.py
@@ -30,7 +30,13 @@ def process_prompt(
 
     try:
         response = backend_func(
-            **backend_config | {"prompts": prompts, "stdin": read_stdin, "debug": debug}
+            **backend_config
+            | {
+                "prompts": prompts,
+                "stdin": read_stdin,
+                "debug": debug,
+                "bool_prompt": bool_prompt,
+            }
         )
     except Exception as err:
         print(f"Failed to process prompt. Reason: f{err}", file=sys.stderr)
@@ -57,6 +63,7 @@ def main():
             backend=args.backend,
             backend_config=backend_config,
         )
+
     except Exception as err:
         print(f"Failed to execute command. Reason: {err}")
         sys.exit(1)

--- a/clai/__init__.py
+++ b/clai/__init__.py
@@ -42,10 +42,13 @@ def process_prompt(
         print(f"Failed to process prompt. Reason: f{err}", file=sys.stderr)
         sys.exit(1)
 
-    print(response, file=sys.stdout)
-
     if bool_prompt:
-        sys.exit(get_exit_code(response))
+        exit_code = get_exit_code(response)
+    else:
+        exit_code = 0
+
+    print(response, file=sys.stdout)
+    sys.exit(exit_code)
 
 
 def main():

--- a/clai/__init__.py
+++ b/clai/__init__.py
@@ -2,7 +2,6 @@
 
 import importlib
 import sys
-from clai.prompts import BOOL_PROMPT, CLOSING_PROMPT, NOPROSE_PROMPT
 from clai.tools import (
     get_backend_instance_config,
     parse_arguments,
@@ -14,7 +13,7 @@ from clai.tools import (
 
 
 def process_prompt(
-    prompt: str, bool_prompt: bool, no_prose_prompt, backend, backend_config
+    prompt: str, bool_prompt: bool, debug: bool, backend, backend_config
 ) -> None:
     """
     Main function to execute the prompt.
@@ -22,50 +21,16 @@ def process_prompt(
     Args:
         prompt: The user provided prompt for the LLM to process.
         bool_prompt: Append `BOOL_PROMPT` content to `prompt`.
-        no_prose_prompt: Append `NOPROSE_PROMPT` content to `prompt`.
         backend: The LLM backend function name to import and execute.
         backend_config: The `backend` function variables.
     """
-    prompts = []
-    response_format = None
+    prompts = [prompt]
 
-    if bool_prompt:
-        response_format = {
-            "type": "json_schema",
-            "json_schema": {
-                "name": "true_false",
-                "schema": {
-                    "type": "object",
-                    "properties": {
-                        "answer": {
-                            "type": "boolean",
-                        },
-                        "reason": {"type": "string"},
-                    },
-                    "required": ["answer", "reason"],
-                    "additionalProperties": False,
-                },
-                "strict": True,
-            },
-        }
-        prompts.append(cleanup(BOOL_PROMPT))
-
-    elif no_prose_prompt:
-        prompts.append(cleanup(NOPROSE_PROMPT))
-
-    prompts.append(cleanup(CLOSING_PROMPT))
-    prompts.append(prompt)
-
-    backend_func = getattr(importlib.import_module("clai.backends"), backend)
+    backend_func = importlib.import_module(f"clai.backend.{backend}").prompt
 
     try:
         response = backend_func(
-            **backend_config
-            | {
-                "prompts": prompts,
-                "stdin": read_stdin,
-                "response_format": response_format,
-            }
+            **backend_config | {"prompts": prompts, "stdin": read_stdin, "debug": debug}
         )
     except Exception as err:
         print(f"Failed to process prompt. Reason: f{err}", file=sys.stderr)
@@ -88,7 +53,7 @@ def main():
         process_prompt(
             prompt=args.prompt,
             bool_prompt=args.bool,
-            no_prose_prompt=args.no_prose,
+            debug=args.debug,
             backend=args.backend,
             backend_config=backend_config,
         )

--- a/clai/backend/__init__.py
+++ b/clai/backend/__init__.py
@@ -1,0 +1,1 @@
+SUPPORTED_BACKENDS = ["azure_openai", "openai", "mistral"]

--- a/clai/backend/azure_openai.py
+++ b/clai/backend/azure_openai.py
@@ -4,7 +4,12 @@
 
 import tiktoken
 from openai import AzureOpenAI
-from clai.backend.openai import ValidateTokenLength, build_messages, RESPONSE_FORMAT
+from clai.backend.openai import (
+    ValidateTokenLength,
+    build_messages,
+    RESPONSE_FORMAT,
+    BOOL_PROMPT,
+)
 
 
 def prompt(
@@ -26,6 +31,12 @@ def prompt(
         azure_endpoint=endpoint,
         api_version=api_version,
     )
+
+    if bool_prompt:
+        response_format = RESPONSE_FORMAT
+        prompts.append(BOOL_PROMPT)
+    else:
+        response_format = None
 
     if base_model is None:
         messages = build_messages(max_tokens, model, system, prompts, stdin)

--- a/clai/backend/azure_openai.py
+++ b/clai/backend/azure_openai.py
@@ -1,0 +1,46 @@
+#
+#  azure_openai.py
+#
+
+import tiktoken
+from openai import AzureOpenAI
+from clai.backend.openai import ValidateTokenLength, build_messages, RESPONSE_FORMAT
+
+
+def prompt(
+    endpoint,
+    api_version,
+    token,
+    max_tokens,
+    model,
+    system,
+    prompts,
+    stdin,
+    temperature=0,
+    base_model=None,
+    bool_prompt=False,
+    debug=False,
+):
+    client = AzureOpenAI(
+        api_key=token,
+        azure_endpoint=endpoint,
+        api_version=api_version,
+    )
+
+    if base_model is None:
+        messages = build_messages(max_tokens, model, system, prompts, stdin)
+    else:
+        messages = build_messages(max_tokens, base_model, system, prompts, stdin)
+
+    if bool_prompt:
+        response_format = RESPONSE_FORMAT
+    else:
+        response_format = None
+
+    if debug:
+        print(messages)
+
+    response = client.chat.completions.create(
+        messages=messages, model=model, temperature=temperature
+    )
+    return response.choices[0].message.content

--- a/clai/backend/mistral.py
+++ b/clai/backend/mistral.py
@@ -8,23 +8,47 @@
 # mistral.py
 #
 from mistralai import Mistral
+import re
+from clai.prompts import BOOL_PROMPT
+
+from mistralai.models import responseformat
+from pydantic import BaseModel
+
+
+class BoolResponseModel(BaseModel):
+    reason: str
+    answer: bool
+
+
+class ValidateTokenLength:
+    def __init__(self, model, max_tokens):
+        self.tokenizer = re.compile(
+            r"\b\w+\b|[^\w\s]"
+        ).findall  # very rudimentary tokenizer
+        self.total_tokens = 0
+        self.max_tokens = max_tokens
+
+    def add(self, data):
+        self.total_tokens += len(self.tokenizer(data))
+        if self.total_tokens > self.max_tokens:
+            raise Exception(f"Total input exceeds {self.total_tokens} tokens.")
 
 
 def build_messages(max_tokens, model, system, prompts, stdin):
     messages = []
 
-    # vtl = ValidateTokenLength(model=model, max_tokens=max_tokens)
+    vtl = ValidateTokenLength(model=model, max_tokens=max_tokens)
 
-    # vtl.add(system)
+    vtl.add(system)
     messages.append({"role": "system", "content": system.lstrip().rstrip()})
 
     for prompt in prompts:
-        # vtl.add(prompt)
+        vtl.add(prompt)
         messages.append({"role": "user", "content": prompt.lstrip().rstrip()})
 
     stdin_content = []
     for line in stdin():
-        # vtl.add(line)
+        vtl.add(line)
         stdin_content.append(line.lstrip().rstrip())
 
     if len(stdin_content) > 0:
@@ -48,11 +72,38 @@ def prompt(
 ):
     client = Mistral(api_key=token)
 
-    messages = build_messages(max_tokens, model, system, prompts, stdin)
+    if bool_prompt:
+        messages = build_messages(
+            max_tokens=max_tokens,
+            model=model,
+            system=BOOL_PROMPT,
+            prompts=prompts,
+            stdin=stdin,
+        )
+    else:
+        messages = build_messages(
+            max_tokens=max_tokens,
+            model=model,
+            system=system,
+            prompts=prompts,
+            stdin=stdin,
+        )
 
     if debug:
         print(messages)
 
-    chat_response = client.chat.complete(model=model, messages=messages)
+    if bool_prompt:
+        chat_response = client.chat.parse(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            response_format=BoolResponseModel,
+        )
+    else:
+        chat_response = client.chat.complete(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+        )
 
     return chat_response.choices[0].message.content

--- a/clai/backend/mistral.py
+++ b/clai/backend/mistral.py
@@ -1,0 +1,58 @@
+# MIT License
+#
+# Copyright (c) 2025 Jelle Smet
+#
+# This software is released under the MIT License.
+# See the LICENSE file in the project root for more information.
+#
+# mistral.py
+#
+from mistralai import Mistral
+
+
+def build_messages(max_tokens, model, system, prompts, stdin):
+    messages = []
+
+    # vtl = ValidateTokenLength(model=model, max_tokens=max_tokens)
+
+    # vtl.add(system)
+    messages.append({"role": "system", "content": system.lstrip().rstrip()})
+
+    for prompt in prompts:
+        # vtl.add(prompt)
+        messages.append({"role": "user", "content": prompt.lstrip().rstrip()})
+
+    stdin_content = []
+    for line in stdin():
+        # vtl.add(line)
+        stdin_content.append(line.lstrip().rstrip())
+
+    if len(stdin_content) > 0:
+        messages.append(
+            {"role": "user", "content": "".join(stdin_content)},
+        )
+
+    return messages
+
+
+def prompt(
+    token,
+    max_tokens,
+    model,
+    system,
+    prompts,
+    stdin,
+    temperature=0,
+    bool_prompt=False,
+    debug=False,
+):
+    client = Mistral(api_key=token)
+
+    messages = build_messages(max_tokens, model, system, prompts, stdin)
+
+    if debug:
+        print(messages)
+
+    chat_response = client.chat.complete(model=model, messages=messages)
+
+    return chat_response.choices[0].message.content

--- a/clai/backend/openai.py
+++ b/clai/backend/openai.py
@@ -5,6 +5,9 @@
 import tiktoken
 from openai import OpenAI
 from clai.prompts import BOOL_PROMPT
+from clai.backend.openai import (
+    BOOL_PROMPT,
+)
 
 RESPONSE_FORMAT = {
     "type": "json_schema",
@@ -78,14 +81,12 @@ def prompt(
     client = OpenAI(api_key=token)
 
     if bool_prompt:
-        prompts.append(BOOL_PROMPT)
-
-    messages = build_messages(max_tokens, model, system, prompts, stdin)
-
-    if bool_prompt:
         response_format = RESPONSE_FORMAT
+        prompts.append(BOOL_PROMPT)
     else:
         response_format = None
+
+    messages = build_messages(max_tokens, model, system, prompts, stdin)
 
     if debug:
         print(messages)

--- a/clai/backend/openai.py
+++ b/clai/backend/openai.py
@@ -82,7 +82,7 @@ def prompt(
 
     if bool_prompt:
         response_format = RESPONSE_FORMAT
-        prompts.append(BOOL_PROMPT)
+        system = BOOL_PROMPT
     else:
         response_format = None
 

--- a/clai/backend/openai.py
+++ b/clai/backend/openai.py
@@ -3,9 +3,27 @@
 #
 
 import tiktoken
-from openai import AzureOpenAI, OpenAI
+from openai import OpenAI
+from clai.prompts import BOOL_PROMPT
 
-SUPPORTED_BACKENDS = ["azure_openai", "openai"]
+RESPONSE_FORMAT = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "true_false",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "answer": {
+                    "type": "boolean",
+                },
+                "reason": {"type": "string"},
+            },
+            "required": ["answer", "reason"],
+            "additionalProperties": False,
+        },
+        "strict": True,
+    },
+}
 
 
 class ValidateTokenLength:
@@ -21,14 +39,10 @@ class ValidateTokenLength:
             raise Exception(f"Total input exceeds {self.total_tokens} tokens.")
 
 
-def build_messages(max_tokens, model, system, prompts, stdin, base_model=None):
-
+def build_messages(max_tokens, model, system, prompts, stdin):
     messages = []
 
-    if base_model:
-        vtl = ValidateTokenLength(model=base_model, max_tokens=max_tokens)
-    else:
-        vtl = ValidateTokenLength(model=model, max_tokens=max_tokens)
+    vtl = ValidateTokenLength(model=model, max_tokens=max_tokens)
 
     vtl.add(system)
     messages.append({"role": "system", "content": system.lstrip().rstrip()})
@@ -50,9 +64,7 @@ def build_messages(max_tokens, model, system, prompts, stdin, base_model=None):
     return messages
 
 
-def azure_openai(
-    endpoint,
-    api_version,
+def prompt(
     token,
     max_tokens,
     model,
@@ -60,38 +72,23 @@ def azure_openai(
     prompts,
     stdin,
     temperature=0,
-    base_model=None,
-    response_format=None,
+    bool_prompt=False,
+    debug=False,
 ):
-    client = AzureOpenAI(
-        api_key=token,
-        azure_endpoint=endpoint,
-        api_version=api_version,
-    )
-
-    messages = build_messages(max_tokens, model, system, prompts, stdin, base_model)
-
-    response = client.chat.completions.create(
-        messages=messages, model=model, temperature=temperature
-    )
-    return response.choices[0].message.content
-
-
-def openai(
-    token,
-    max_tokens,
-    model,
-    system,
-    prompts,
-    stdin,
-    temperature=0,
-    base_model=None,
-    response_format=None,
-):
-
     client = OpenAI(api_key=token)
 
-    messages = build_messages(max_tokens, model, system, prompts, stdin, base_model)
+    if bool_prompt:
+        prompts.append(BOOL_PROMPT)
+
+    messages = build_messages(max_tokens, model, system, prompts, stdin)
+
+    if bool_prompt:
+        response_format = RESPONSE_FORMAT
+    else:
+        response_format = None
+
+    if debug:
+        print(messages)
 
     response = client.chat.completions.create(
         messages=messages,

--- a/clai/prompts.py
+++ b/clai/prompts.py
@@ -15,16 +15,3 @@ AZURE_BOOL_PROMPT = """
     1. answer (type:bool ) – A definitive 'True' or 'False' based on the given information.
     2. reason (type:string) – A brief explanation justifying both the answer and whether the context was sufficient or not."
 """
-
-NOPROSE_PROMPT = """
-    - You are not allowed to return anything else than the requested content
-    - You are not allowed to add any additional comments
-    - You are not allowed to return anything else than plain text
-    - You are not allowed to change the input format
-    - You are not allowed include example usage
-"""
-
-CLOSING_PROMPT = """
-    If you do not execute these instructions exactly as requested your answer will 
-    be considered wrong.
-"""

--- a/clai/prompts.py
+++ b/clai/prompts.py
@@ -9,6 +9,13 @@ BOOL_PROMPT = """
     2. Reason – A brief explanation justifying both the answer and whether the context was sufficient or not."
 """
 
+AZURE_BOOL_PROMPT = """
+    Analyze the following statement or question without inferring missing
+    information and provide a structured JSON response containing two elements:
+    1. answer (type:bool ) – A definitive 'True' or 'False' based on the given information.
+    2. reason (type:string) – A brief explanation justifying both the answer and whether the context was sufficient or not."
+"""
+
 NOPROSE_PROMPT = """
     - You are not allowed to return anything else than the requested content
     - You are not allowed to add any additional comments

--- a/clai/tools.py
+++ b/clai/tools.py
@@ -9,17 +9,15 @@ import sys
 from textwrap import dedent
 import yaml
 
-from clai.backends import SUPPORTED_BACKENDS
+from clai.backend import SUPPORTED_BACKENDS
 import json
 
 
 def cleanup(text):
-
     return dedent(text).replace("\n", " ")
 
 
 def get_exit_code(response):
-
     json_response = json.loads(response)
     if json_response["answer"]:
         return 0
@@ -107,11 +105,6 @@ def parse_arguments():
         help="Forces the llm to answer with `yes`, `no` or `inconclusive` whilst exiting with a corresponding exit code 0, 1, 2 respectively.",
     )
     main.add_argument(
-        "--no-prose",
-        action="store_true",
-        help="Forces the llm to only return what is asked without any further prose.",
-    )
-    main.add_argument(
         "--config",
         type=str,
         required=True,
@@ -134,6 +127,11 @@ def parse_arguments():
         action=EnvDefault,
         envvar="CLAI_INSTANCE",
         help="The backend instance to select from `config`.",
+    )
+    main.add_argument(
+        "--debug",
+        action="store_true",
+        help="Shows debugging output",
     )
 
     return main.parse_args()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ authors = [
 dependencies = [
     "openai>=1.58.1",
     "tiktoken>=0.8.0",
-    "pyyaml>=6.0.2"
+    "pyyaml>=6.0.2",
+    "mistralai>=1.5.1"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "openai>=1.58.1",
     "tiktoken>=0.8.0",
     "pyyaml>=6.0.2",
+    "pydantic>=2.10.6",
+    "jsonschema>=4.23.0",
     "mistralai>=1.5.1"
 ]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,3 +73,11 @@ def test_mistral_bool():
     )
 
     assert json.loads(result["stdout"])["answer"] is True
+
+
+def test_pipe_stdin():
+    result = execute_command(
+        'echo "black and white" | clai --backend mistral --prompt "mixing these colors yields grey." --bool'
+    )
+
+    assert json.loads(result["stdout"])["answer"] is True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,75 @@
+import subprocess
+import json
+
+
+def execute_command(command):
+    """
+    Executes a CLI command and returns the output and error (if any).
+
+    Args:
+        command (str): The command to execute.
+
+    Returns:
+        dict: A dictionary containing 'stdout', 'stderr', and 'returncode'.
+    """
+    try:
+        result = subprocess.run(
+            command,
+            shell=True,  # Enables executing shell commands
+            capture_output=True,  # Captures both stdout and stderr
+            text=True,  # Returns output as a string
+        )
+
+        return {
+            "stdout": result.stdout.strip(),
+            "stderr": result.stderr.strip(),
+            "returncode": result.returncode,
+        }
+
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def test_openai():
+    result = execute_command(
+        'clai --backend openai --prompt "say hello in lowercase and nothing more not even punctuation."'
+    )
+    assert result["stdout"] == "hello"
+
+
+def test_openai_bool():
+    result = execute_command(
+        'clai --backend openai --prompt "mixing black and white yields grey" --bool'
+    )
+
+    assert json.loads(result["stdout"])["answer"] is True
+
+
+def test_azure_openai():
+    result = execute_command(
+        'clai --backend azure_openai --prompt "say hello in lowercase and nothing more not even punctuation."'
+    )
+    assert result["stdout"] == "hello"
+
+
+def test_azure_openai_bool():
+    result = execute_command(
+        'clai --backend azure_openai --prompt "mixing black and white yields grey" --bool'
+    )
+
+    assert json.loads(result["stdout"])["answer"] is True
+
+
+def test_mistral():
+    result = execute_command(
+        'clai --backend mistral --prompt "say hello in lowercase and nothing more not even punctuation."'
+    )
+    assert result["stdout"] == "hello"
+
+
+def test_mistral_bool():
+    result = execute_command(
+        'clai --backend mistral --prompt "mixing black and white yields grey" --bool'
+    )
+
+    assert json.loads(result["stdout"])["answer"] is True


### PR DESCRIPTION
# What
- Added support for [Mistral.ai](https://mistral.ai/)
- Removed `--no-prose` parameter, this can be achieved by extending system prompt
- Fixed `--bool` support for azure_openai.
- Added tests for command execution
